### PR TITLE
Fix #111 Issue作成時にラベルを選択できるようにする

### DIFF
--- a/src/__tests__/cli-routing-issue-resolve.test.ts
+++ b/src/__tests__/cli-routing-issue-resolve.test.ts
@@ -41,6 +41,7 @@ vi.mock('../features/tasks/index.js', () => ({
   determinePiece: vi.fn(),
   saveTaskFromInteractive: vi.fn(),
   createIssueAndSaveTask: vi.fn(),
+  promptLabelSelection: vi.fn().mockResolvedValue([]),
 }));
 
 vi.mock('../features/pipeline/index.js', () => ({
@@ -446,7 +447,7 @@ describe('Issue resolution in routing', () => {
         '/test/cwd',
         'New feature request',
         'default',
-        { confirmAtEndMessage: 'Add this issue to tasks?' },
+        { confirmAtEndMessage: 'Add this issue to tasks?', labels: [] },
       );
     });
 

--- a/src/__tests__/createIssueFromTask.test.ts
+++ b/src/__tests__/createIssueFromTask.test.ts
@@ -164,4 +164,64 @@ describe('createIssueFromTask', () => {
       body: task,
     });
   });
+
+  describe('labels option', () => {
+    it('should pass labels to createIssue when provided', () => {
+      // Given
+      mockCreateIssue.mockReturnValue({ success: true, url: 'https://github.com/owner/repo/issues/1' });
+
+      // When
+      createIssueFromTask('Test task', { labels: ['bug'] });
+
+      // Then
+      expect(mockCreateIssue).toHaveBeenCalledWith({
+        title: 'Test task',
+        body: 'Test task',
+        labels: ['bug'],
+      });
+    });
+
+    it('should not include labels key when options is undefined', () => {
+      // Given
+      mockCreateIssue.mockReturnValue({ success: true, url: 'https://github.com/owner/repo/issues/1' });
+
+      // When
+      createIssueFromTask('Test task');
+
+      // Then
+      expect(mockCreateIssue).toHaveBeenCalledWith({
+        title: 'Test task',
+        body: 'Test task',
+      });
+    });
+
+    it('should not include labels key when labels is empty array', () => {
+      // Given
+      mockCreateIssue.mockReturnValue({ success: true, url: 'https://github.com/owner/repo/issues/1' });
+
+      // When
+      createIssueFromTask('Test task', { labels: [] });
+
+      // Then
+      expect(mockCreateIssue).toHaveBeenCalledWith({
+        title: 'Test task',
+        body: 'Test task',
+      });
+    });
+
+    it('should filter out empty string labels', () => {
+      // Given
+      mockCreateIssue.mockReturnValue({ success: true, url: 'https://github.com/owner/repo/issues/1' });
+
+      // When
+      createIssueFromTask('Test task', { labels: ['bug', '', 'enhancement'] });
+
+      // Then
+      expect(mockCreateIssue).toHaveBeenCalledWith({
+        title: 'Test task',
+        body: 'Test task',
+        labels: ['bug', 'enhancement'],
+      });
+    });
+  });
 });

--- a/src/app/cli/routing.ts
+++ b/src/app/cli/routing.ts
@@ -9,7 +9,7 @@ import { info, error as logError, withProgress } from '../../shared/ui/index.js'
 import { getErrorMessage } from '../../shared/utils/index.js';
 import { getLabel } from '../../shared/i18n/index.js';
 import { fetchIssue, formatIssueAsTask, checkGhCli, parseIssueNumbers, type GitHubIssue } from '../../infra/github/index.js';
-import { selectAndExecuteTask, determinePiece, saveTaskFromInteractive, createIssueFromTask, type SelectAndExecuteOptions } from '../../features/tasks/index.js';
+import { selectAndExecuteTask, determinePiece, saveTaskFromInteractive, createIssueAndSaveTask, type SelectAndExecuteOptions } from '../../features/tasks/index.js';
 import { executePipeline } from '../../features/pipeline/index.js';
 import {
   interactiveMode,
@@ -218,13 +218,9 @@ export async function executeDefaultAction(task?: string): Promise<void> {
       await selectAndExecuteTask(resolvedCwd, confirmedTask, selectOptions, agentOverrides);
     },
     create_issue: async ({ task: confirmedTask }) => {
-      const issueNumber = createIssueFromTask(confirmedTask);
-      if (issueNumber !== undefined) {
-        await saveTaskFromInteractive(resolvedCwd, confirmedTask, pieceId, {
-          issue: issueNumber,
-          confirmAtEndMessage: 'Add this issue to tasks?',
-        });
-      }
+      await createIssueAndSaveTask(resolvedCwd, confirmedTask, pieceId, {
+        confirmAtEndMessage: 'Add this issue to tasks?',
+      });
     },
     save_task: async ({ task: confirmedTask }) => {
       await saveTaskFromInteractive(resolvedCwd, confirmedTask, pieceId);

--- a/src/app/cli/routing.ts
+++ b/src/app/cli/routing.ts
@@ -9,7 +9,7 @@ import { info, error as logError, withProgress } from '../../shared/ui/index.js'
 import { getErrorMessage } from '../../shared/utils/index.js';
 import { getLabel } from '../../shared/i18n/index.js';
 import { fetchIssue, formatIssueAsTask, checkGhCli, parseIssueNumbers, type GitHubIssue } from '../../infra/github/index.js';
-import { selectAndExecuteTask, determinePiece, saveTaskFromInteractive, createIssueAndSaveTask, type SelectAndExecuteOptions } from '../../features/tasks/index.js';
+import { selectAndExecuteTask, determinePiece, saveTaskFromInteractive, createIssueAndSaveTask, promptLabelSelection, type SelectAndExecuteOptions } from '../../features/tasks/index.js';
 import { executePipeline } from '../../features/pipeline/index.js';
 import {
   interactiveMode,
@@ -218,8 +218,10 @@ export async function executeDefaultAction(task?: string): Promise<void> {
       await selectAndExecuteTask(resolvedCwd, confirmedTask, selectOptions, agentOverrides);
     },
     create_issue: async ({ task: confirmedTask }) => {
+      const labels = await promptLabelSelection(lang);
       await createIssueAndSaveTask(resolvedCwd, confirmedTask, pieceId, {
         confirmAtEndMessage: 'Add this issue to tasks?',
+        labels,
       });
     },
     save_task: async ({ task: confirmedTask }) => {

--- a/src/features/tasks/add/index.ts
+++ b/src/features/tasks/add/index.ts
@@ -9,6 +9,7 @@ import * as fs from 'node:fs';
 import { promptInput, confirm, selectOption } from '../../../shared/prompt/index.js';
 import { success, info, error, withProgress } from '../../../shared/ui/index.js';
 import { getLabel } from '../../../shared/i18n/index.js';
+import type { Language } from '../../../core/models/types.js';
 import { TaskRunner, type TaskFileData, summarizeTaskName } from '../../../infra/task/index.js';
 import { determinePiece } from '../execute/selectAndExecute.js';
 import { createLogger, getErrorMessage, generateReportDir } from '../../../shared/utils/index.js';
@@ -139,10 +140,9 @@ export async function createIssueAndSaveTask(
   cwd: string,
   task: string,
   piece?: string,
-  options?: { confirmAtEndMessage?: string },
+  options?: { confirmAtEndMessage?: string; labels?: string[] },
 ): Promise<void> {
-  const labels = await promptLabelSelection();
-  const issueNumber = createIssueFromTask(task, { labels });
+  const issueNumber = createIssueFromTask(task, { labels: options?.labels });
   if (issueNumber !== undefined) {
     await saveTaskFromInteractive(cwd, task, piece, {
       issue: issueNumber,
@@ -157,20 +157,20 @@ export async function createIssueAndSaveTask(
  * Presents 4 fixed options: None, bug, enhancement, custom input.
  * Returns an array of selected labels (empty if none selected).
  */
-async function promptLabelSelection(): Promise<string[]> {
+export async function promptLabelSelection(lang: Language): Promise<string[]> {
   const selected = await selectOption<string>(
-    getLabel('issue.labelSelection.prompt'),
+    getLabel('issue.labelSelection.prompt', lang),
     [
-      { label: getLabel('issue.labelSelection.none'), value: 'none' },
+      { label: getLabel('issue.labelSelection.none', lang), value: 'none' },
       { label: 'bug', value: 'bug' },
       { label: 'enhancement', value: 'enhancement' },
-      { label: getLabel('issue.labelSelection.custom'), value: 'custom' },
+      { label: getLabel('issue.labelSelection.custom', lang), value: 'custom' },
     ],
   );
 
   if (selected === null || selected === 'none') return [];
   if (selected === 'custom') {
-    const customLabel = await promptInput(getLabel('issue.labelSelection.customPrompt'));
+    const customLabel = await promptInput(getLabel('issue.labelSelection.customPrompt', lang));
     return customLabel?.split(',').map((l) => l.trim()).filter((l) => l.length > 0) ?? [];
   }
   return [selected];

--- a/src/features/tasks/index.ts
+++ b/src/features/tasks/index.ts
@@ -16,7 +16,7 @@ export {
   type WorktreeConfirmationResult,
 } from './execute/selectAndExecute.js';
 export { resolveAutoPr, postExecutionFlow, type PostExecutionOptions } from './execute/postExecution.js';
-export { addTask, saveTaskFile, saveTaskFromInteractive, createIssueFromTask, createIssueAndSaveTask } from './add/index.js';
+export { addTask, saveTaskFile, saveTaskFromInteractive, createIssueFromTask, createIssueAndSaveTask, promptLabelSelection } from './add/index.js';
 export { watchTasks } from './watch/index.js';
 export {
   listTasks,

--- a/src/shared/i18n/labels_en.yaml
+++ b/src/shared/i18n/labels_en.yaml
@@ -103,3 +103,11 @@ retry:
 run:
   notifyComplete: "Run complete ({total} tasks)"
   notifyAbort: "Run finished with errors ({failed})"
+
+# ===== Issue Creation UI =====
+issue:
+  labelSelection:
+    prompt: "Label:"
+    none: "None"
+    custom: "Custom input"
+    customPrompt: "Enter label name"

--- a/src/shared/i18n/labels_ja.yaml
+++ b/src/shared/i18n/labels_ja.yaml
@@ -103,3 +103,11 @@ retry:
 run:
   notifyComplete: "run完了 ({total} tasks)"
   notifyAbort: "runはエラー終了 ({failed})"
+
+# ===== Issue Creation UI =====
+issue:
+  labelSelection:
+    prompt: "ラベル:"
+    none: "なし"
+    custom: "入力（カスタム）"
+    customPrompt: "ラベル名を入力"


### PR DESCRIPTION
- close #111

## 概要

`takt add` / インタラクティブモードで Issue を作成する際に、ラベルを選択できる機能を追加する。

## 変更内容

### 機能追加
- `promptLabelSelection` を追加し、ラベル選択UI（なし / bug / enhancement / カスタム入力）を実装
- カスタム入力時はカンマ区切りで複数ラベルを指定可能
- `filterExistingLabels` を追加し、リポジトリに存在しないラベルを自動除外

### 存在しないラベルの扱いについて

`gh issue create --label <name>` はリポジトリに存在しないラベルを指定するとエラーで失敗する（Issue作成自体が行われない）。
この問題に対し、`filterExistingLabels` で `gh label list` を事前に取得し、存在するラベルのみを付与するようにした。

現状、存在しないラベルがスキップされた場合にユーザへの通知は行われない（サイレントにフィルタリングされる）。
ユーザへの通知方法（info メッセージ表示、`CreateIssueResult` に `skippedLabels` を追加等）は別途 Issue を作成して対応する必要がある

## 確認した内容

- [x] test/lint パス
- [x] 手動テスト: ラベル選択UIの動作確認（なし / bug / enhancement / カスタム入力）
- [x] 手動テスト: 存在しないラベル指定時にエラーにならずIssue作成される

<img width="500" alt="Screenshot 2026-02-24 at 14 43 52" src="https://github.com/user-attachments/assets/fcab0572-8498-4361-98ac-bb7a43ea4c08" />

<img width="500" alt="Screenshot 2026-02-24 at 14 43 37" src="https://github.com/user-attachments/assets/380694d3-1577-4baa-9608-d9ed7b565db9" />